### PR TITLE
Add BinarySearch tests and Maven config

### DIFF
--- a/DataStructureUsingJava/test/searching/BinarySearchTest.java
+++ b/DataStructureUsingJava/test/searching/BinarySearchTest.java
@@ -1,0 +1,35 @@
+package searching;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+public class BinarySearchTest {
+    @Test
+    public void searchReturnsTrueForSingleElementArray() {
+        BinarySearch bs = new BinarySearch();
+        int[] arr = {5};
+        assertTrue(bs.search(arr, 5));
+    }
+
+    @Test
+    public void searchReturnsFalseForMissingKeyInSingleElementArray() {
+        BinarySearch bs = new BinarySearch();
+        int[] arr = {5};
+        assertFalse(bs.search(arr, 3));
+    }
+
+    @Test
+    public void searchReturnsTrueForKeyPresentInMultiElementArray() {
+        BinarySearch bs = new BinarySearch();
+        int[] arr = {1, 3, 5, 7, 9};
+        assertTrue(bs.search(arr, 7));
+    }
+
+    @Test
+    public void searchReturnsFalseForMissingKeyInMultiElementArray() {
+        BinarySearch bs = new BinarySearch();
+        int[] arr = {1, 3, 5, 7, 9};
+        assertFalse(bs.search(arr, 2));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>datastructure</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <build>
+        <sourceDirectory>DataStructureUsingJava/src</sourceDirectory>
+        <testSourceDirectory>DataStructureUsingJava/test</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
## Summary
- add `BinarySearchTest` for simple true/false cases
- add minimal Maven `pom.xml` so tests run via `mvn test`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840851c6b508332ab75ac0624dca970