### PR TITLE
Fix bugs in binary search and postorder traversal

### DIFF
--- a/DataStructureUsingJava/src/searching/BinarySearch.java
+++ b/DataStructureUsingJava/src/searching/BinarySearch.java
@@ -3,9 +3,9 @@ package searching;
 public class BinarySearch implements Search {
 
 	@Override
-	public boolean search(int[] array, int key) {
-		int low=0,up=array.length;
-		for(int mid=(low+up)/2;low<=up;mid=(low+up)/2) {
+        public boolean search(int[] array, int key) {
+                int low=0,up=array.length-1;
+                for(int mid=(low+up)/2;low<=up;mid=(low+up)/2) {
 			if(array[mid] == key)
 				return true;
 			if(array[mid]<key)

--- a/DataStructureUsingJava/src/tree/BSTree.java
+++ b/DataStructureUsingJava/src/tree/BSTree.java
@@ -97,13 +97,13 @@ public class BSTree implements Serializable, Cloneable {
 		postorder(this.root);
 	}
 
-	private void postorder(Node root) {
-		if (root != null) {
-			preorder(root.leftChild);
-			preorder(root.rightChild);
-			System.out.print(root.data + " ");
-		}
-	}
+       private void postorder(Node root) {
+               if (root != null) {
+                       postorder(root.leftChild);
+                       postorder(root.rightChild);
+                       System.out.print(root.data + " ");
+               }
+       }
 
 	public int getLength() {
 		return this.getCount();


### PR DESCRIPTION
## Summary
- correct upper bound in `BinarySearch` implementation
- fix recursion in `BSTree` postorder traversal

## Testing
- `find DataStructureUsingJava/src -name '*.java' | tr '\n' ' ' | xargs javac`

------
https://chatgpt.com/codex/tasks/task_e_6840845728c0833286cc7644ba2440f0